### PR TITLE
Add ... to reduce_bib

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.1.9001
 Imports: 
     stringr,
     RefManageR

--- a/R/reduce-bib.R
+++ b/R/reduce-bib.R
@@ -43,12 +43,13 @@ write_bib <- function(bib, ...) {
 #' @param master_bib path to whistle/master.bib (or any other central .bib file 
 #'   for that matter)
 #' @param out_bib path/name of the output .bib file to write
+#' @param ... Arguments passed to [RefManageR::ReadBib()]
 #' 
 #' @export
-reduce_bib <- function(file, master_bib, out_bib) {
+reduce_bib <- function(file, master_bib, out_bib, ...) {
   doc <- readLines(file)
   cite_keys <- extract_cite_keys(doc)
-  master    <- read_bib(master_bib)
+  master    <- read_bib(master_bib, ...)
   bib       <- master[cite_keys]
   if (!all(cite_keys %in% names(master))) {
     missing <- cite_keys[!cite_keys %in% names(master)]

--- a/man/reduce_bib.Rd
+++ b/man/reduce_bib.Rd
@@ -4,7 +4,7 @@
 \alias{reduce_bib}
 \title{Reduce a central .bib file down to used elements}
 \usage{
-reduce_bib(file, master_bib, out_bib)
+reduce_bib(file, master_bib, out_bib, ...)
 }
 \arguments{
 \item{file}{path to the target .Rmd file}
@@ -13,6 +13,8 @@ reduce_bib(file, master_bib, out_bib)
 for that matter)}
 
 \item{out_bib}{path/name of the output .bib file to write}
+
+\item{...}{Arguments passed to \code{\link[RefManageR:ReadBib]{RefManageR::ReadBib()}}}
 }
 \description{
 Condense a master.bib file to only the references that are used in a paper.


### PR DESCRIPTION
I think it's quite useful, especially when the master bib file is not well-formed. The default behavior, which makes a lot of sense, is to drop malformed entries. But it can be a surprise, not least because the RMD file can be compiled. In those cases, it would be useful to add "check = FALSE".

Thank you for your package. It is now central to my RMD workflow.