### PR TITLE
Make `reduce_bib` accept a vector of Rmds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,8 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
 Imports: 
     stringr,
-    RefManageR
+    RefManageR,
+    bibtex
 Suggests: 
     testthat,
     covr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,18 +2,23 @@ Package: condensebib
 Title: Condense a Central Bibliography to Locally-needed Subset
 Version: 0.1.0
 Authors@R: 
-    person(given = "Andreas",
+    c(person(given = "Andreas",
            family = "Beger",
            role = c("aut", "cre"),
            email = "adbeger@gmail.com",
-           comment = c(ORCID = "0000-0003-1883-3169"))
+           comment = c(ORCID = "0000-0003-1883-3169")),
+      person(given = "Chung-hong",
+	   family = "Chan",
+	   role = c("ctb"),
+	   email = "chainsawtiney@gmail.com",
+	   comment = c(ORCID = "0000-0002-6232-7530")))
 Description: Condense a large central .bib file to a smaller local version that
     only contains references that are used in a local Rmarkdown document.
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1.9001
+RoxygenNote: 7.1.2
 Imports: 
     stringr,
     RefManageR

--- a/R/reduce-bib.R
+++ b/R/reduce-bib.R
@@ -37,9 +37,10 @@ write_bib <- function(bib, ...) {
 
 #' Reduce a central .bib file down to used elements
 #' 
-#' Condense a master.bib file to only the references that are used in a paper.
+#' Condense a master.bib file to only the references that are used in a paper or
+#' multiple papers.
 #' 
-#' @param file path to the target .Rmd file
+#' @param file path to the target .Rmd file; or a vector of .Rmd files
 #' @param master_bib path to whistle/master.bib (or any other central .bib file 
 #'   for that matter)
 #' @param out_bib path/name of the output .bib file to write
@@ -47,8 +48,8 @@ write_bib <- function(bib, ...) {
 #' 
 #' @export
 reduce_bib <- function(file, master_bib, out_bib, ...) {
-  doc <- readLines(file)
-  cite_keys <- extract_cite_keys(doc)
+  doc <- lapply(file, readLines)
+  cite_keys <- sort(unique(unlist(lapply(doc, extract_cite_keys))))
   master    <- read_bib(master_bib, ...)
   bib       <- master[cite_keys]
   if (!all(cite_keys %in% names(master))) {

--- a/R/reduce-bib.R
+++ b/R/reduce-bib.R
@@ -34,6 +34,12 @@ write_bib <- function(bib, ...) {
   RefManageR::WriteBib(bib, ...)
 }
 
+## RefMangageR actually suggests `bibtex`
+## But it won't make it available to this package and write_bib needs bibtex
+## We need to make it explicit
+.write <- function(x) {
+  bibtex::write.bib(x)
+}
 
 #' Reduce a central .bib file down to used elements
 #' 

--- a/man/reduce_bib.Rd
+++ b/man/reduce_bib.Rd
@@ -7,7 +7,7 @@
 reduce_bib(file, master_bib, out_bib, ...)
 }
 \arguments{
-\item{file}{path to the target .Rmd file}
+\item{file}{path to the target .Rmd file; or a vector of .Rmd files}
 
 \item{master_bib}{path to whistle/master.bib (or any other central .bib file
 for that matter)}
@@ -17,5 +17,6 @@ for that matter)}
 \item{...}{Arguments passed to \code{\link[RefManageR:ReadBib]{RefManageR::ReadBib()}}}
 }
 \description{
-Condense a master.bib file to only the references that are used in a paper.
+Condense a master.bib file to only the references that are used in a paper or
+multiple papers.
 }

--- a/tests/testdata/main.bib
+++ b/tests/testdata/main.bib
@@ -1,0 +1,44 @@
+@book{wickham2016,
+  title={{R for data science: import, tidy, transform, visualize, and model data}},
+  author={Wickham, Hadley and Grolemund, Garrett},
+  year={2016},
+  publisher={" O'Reilly Media, Inc."}
+}
+
+@article{wickham2011,
+  title={The split-apply-combine strategy for data analysis},
+  author={Wickham, Hadley},
+  journal={Journal of Statistical Software},
+  volume={40},
+  number={1},
+  pages={1--29},
+  year={2011},
+  publisher={Citeseer},
+  doi={10.18637/jss.v040.i01}
+}
+
+@book{cohen2013statistical,
+  title={Statistical power analysis for the behavioral sciences},
+  author={Cohen, Jacob},
+  year={2013},
+  publisher={Academic press}
+}
+
+@manual{rcore,
+    title = {R: A Language and Environment for Statistical Computing},
+    author = {{R Core Team}},
+    organization = {R Foundation for Statistical Computing},
+    address = {Vienna, Austria},
+    year = {2021},
+    url = {https://www.R-project.org/},
+}
+
+@book{eddelbuettel,
+  author       = {Eddelbuettel, Dirk},
+  title	       = {{Seamless R and C++ Integration with Rcpp}},
+  year	       = 2013,
+  doi	       = {10.1007/978-1-4614-6868-4},
+  url	       = {http://dx.doi.org/10.1007/978-1-4614-6868-4},
+  isbn	       = 9781461468684,
+  publisher    = {Springer New York}
+}

--- a/tests/testdata/r1.rmd
+++ b/tests/testdata/r1.rmd
@@ -1,0 +1,5 @@
+# Chapter 1
+
+@wickham2016 discuss the tidyverse ecosystem. These books are also useful. [e.g. @eddelbuettel;@rcore].
+
+

--- a/tests/testdata/r2.rmd
+++ b/tests/testdata/r2.rmd
@@ -1,0 +1,3 @@
+# Chapter 2
+
+We cited @wickham2011 and @wickham2016. 

--- a/tests/testthat/test-condense.R
+++ b/tests/testthat/test-condense.R
@@ -1,0 +1,20 @@
+test_that("single RMarkdown file", {
+  rmd_files <- "../testdata/r2.rmd"
+  tmp_bib <- tempfile(fileext = ".bib")
+  reduce_bib(rmd_files, "../testdata/main.bib", tmp_bib, check = FALSE)
+  x <- read_bib(tmp_bib, check = FALSE)
+  expect_equal(length(x), 2) ## only two cites
+  dois <- lapply(x, function(g) g$doi)
+  expect_true(dois[[1]] == "10.18637/jss.v040.i01")
+  expect_true(is.null(dois[[2]]))
+  unlink(tmp_bib)
+})
+
+test_that("multiple RMarkdown files", {
+  rmd_files <- c("../testdata/r1.rmd", "../testdata/r2.rmd")
+  tmp_bib <- tempfile(fileext = ".bib")
+  reduce_bib(rmd_files, "../testdata/main.bib", tmp_bib, check = FALSE)
+  x <- read_bib(tmp_bib, check = FALSE)
+  expect_equal(length(x), 4) ## cohen is not there
+  unlink(tmp_bib)
+})


### PR DESCRIPTION
It is useful in the situation of a project with multiple RMarkdown
files. A `bookdown` project is a great example.